### PR TITLE
Fix bug with jukebox crashing dedicated server

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ org.gradle.jvmargs=-Xmx1G
 	loader_version=0.9.3+build.207
 
 # Mod Properties
-	mod_version = 0.1.0-beta
+	mod_version = 0.1.1-beta
 	maven_group = io.github.foundationgames
 	archives_base_name = phonos
 

--- a/src/main/java/io/github/foundationgames/phonos/block/RadioNoteBlock.java
+++ b/src/main/java/io/github/foundationgames/phonos/block/RadioNoteBlock.java
@@ -59,7 +59,7 @@ public class RadioNoteBlock extends Block implements RadioChannelBlock {
     private void playNote(World world, BlockPos pos) {
         if(!world.isClient()) {
             RadioChannelState pstate = PhonosUtil.getRadioState((ServerWorld)world);
-            pstate.playSound(pos, Instrument.fromBlockState(world.getBlockState(pos.down())).getSound(), world.getBlockState(pos).get(CHANNEL), 1.8f, (float)Math.pow(2.0D, (double)(world.getBlockState(pos).get(NOTE) - 12) / 12.0D), false);
+            pstate.playSound(pos, Instrument.fromBlockState(world.getBlockState(pos.down())), world.getBlockState(pos).get(CHANNEL), 1.8f, (float)Math.pow(2.0D, (double)(world.getBlockState(pos).get(NOTE) - 12) / 12.0D), false);
         }
     }
 

--- a/src/main/java/io/github/foundationgames/phonos/block/entity/RadioJukeboxBlockEntity.java
+++ b/src/main/java/io/github/foundationgames/phonos/block/entity/RadioJukeboxBlockEntity.java
@@ -5,7 +5,6 @@ import io.github.foundationgames.phonos.Phonos;
 import io.github.foundationgames.phonos.block.PhonosBlocks;
 import io.github.foundationgames.phonos.block.RadioJukeboxBlock;
 import io.github.foundationgames.phonos.item.CustomMusicDiscItem;
-import io.github.foundationgames.phonos.mixin.MusicDiscItemAccess;
 import io.github.foundationgames.phonos.screen.RadioJukeboxGuiDescription;
 import io.github.foundationgames.phonos.util.PhonosUtil;
 import io.github.foundationgames.phonos.world.RadioChannelState;
@@ -113,7 +112,7 @@ public class RadioJukeboxBlockEntity extends BlockEntity implements ExtendedScre
             RadioChannelState pstate = PhonosUtil.getRadioState((ServerWorld)world);
             ItemStack disc = items.get(slot);
             if(disc.getItem() instanceof MusicDiscItem) {
-                pstate.playSound(pos, ((MusicDiscItemAccess)disc.getItem()).getSoundEvent(), getChannel(), 1.8f, pitch, true);
+                pstate.playSound(pos, Item.getRawId(disc.getItem()), getChannel(), 1.8f, pitch, true);
             }
             if(disc.getItem() instanceof CustomMusicDiscItem) {
                 Identifier id = Identifier.tryParse(disc.getOrCreateSubTag("MusicData").getString("SoundId"));

--- a/src/main/java/io/github/foundationgames/phonos/network/PayloadPackets.java
+++ b/src/main/java/io/github/foundationgames/phonos/network/PayloadPackets.java
@@ -5,6 +5,7 @@ import io.github.foundationgames.phonos.block.entity.RadioJukeboxBlockEntity;
 import io.github.foundationgames.phonos.screen.CustomMusicDiscGuiDescription;
 import io.netty.buffer.Unpooled;
 import net.fabricmc.fabric.api.network.ServerSidePacketRegistry;
+import net.minecraft.block.enums.Instrument;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.network.PacketByteBuf;
 import net.minecraft.sound.SoundEvent;
@@ -25,10 +26,21 @@ public final class PayloadPackets {
         ServerSidePacketRegistry.INSTANCE.sendToPlayer(player, Phonos.id("jukebox_song_by_id"), buf);
     }
 
-    public static void sendRadioChannelSound(PlayerEntity player, BlockPos origin, SoundEvent sound, int channel, float volume, float pitch, boolean stoppable) {
+    public static void sendRadioChannelSound(PlayerEntity player, BlockPos origin, Instrument instrument, int channel, float volume, float pitch, boolean stoppable) {
         PacketByteBuf buf = new PacketByteBuf(Unpooled.buffer());
         buf.writeBlockPos(origin);
-        buf.writeIdentifier(sound.getId());
+        buf.writeString(instrument.toString());
+        buf.writeInt(channel);
+        buf.writeFloat(volume);
+        buf.writeFloat(pitch);
+        buf.writeBoolean(stoppable);
+        ServerSidePacketRegistry.INSTANCE.sendToPlayer(player, Phonos.id("radio_channel_sound_by_instrument"), buf);
+    }
+
+    public static void sendRadioChannelSound(PlayerEntity player, BlockPos origin, int itemID, int channel, float volume, float pitch, boolean stoppable) {
+        PacketByteBuf buf = new PacketByteBuf(Unpooled.buffer());
+        buf.writeBlockPos(origin);
+        buf.writeInt(itemID);
         buf.writeInt(channel);
         buf.writeFloat(volume);
         buf.writeFloat(pitch);

--- a/src/main/java/io/github/foundationgames/phonos/world/RadioChannelState.java
+++ b/src/main/java/io/github/foundationgames/phonos/world/RadioChannelState.java
@@ -6,11 +6,11 @@ import io.github.foundationgames.phonos.network.RecieverStorageOperation;
 import io.github.foundationgames.phonos.util.PhonosUtil;
 import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
 import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
+import net.minecraft.block.enums.Instrument;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.server.world.ServerWorld;
-import net.minecraft.sound.SoundEvent;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.PersistentState;
@@ -100,8 +100,12 @@ public class RadioChannelState extends PersistentState {
         //Phonos.LOG.info("---- FINISHED SENDING JOIN PACKETS ----");
     }
 
-    public void playSound(BlockPos origin, SoundEvent sound, int channel, float volume, float pitch, boolean stoppable) {
-        for(PlayerEntity player : world.getPlayers()) PayloadPackets.sendRadioChannelSound(player, origin, sound, channel, volume, pitch, stoppable);
+    public void playSound(BlockPos origin, Instrument instrument, int channel, float volume, float pitch, boolean stoppable) {
+        for(PlayerEntity player : world.getPlayers()) PayloadPackets.sendRadioChannelSound(player, origin, instrument, channel, volume, pitch, stoppable);
+    }
+
+    public void playSound(BlockPos origin, int itemID, int channel, float volume, float pitch, boolean stoppable) {
+        for(PlayerEntity player : world.getPlayers()) PayloadPackets.sendRadioChannelSound(player, origin, itemID, channel, volume, pitch, stoppable);
     }
 
     public void playSound(BlockPos origin, Identifier sound, int channel, float volume, float pitch, boolean stoppable) {


### PR DESCRIPTION
Fixes #2  

The dedicated server does not have access to the SoundEvent.getID() function, and it had to be replaced with
sending the ID of the music disk for built in disks. Instruments also have their enum sent to the client
in order to bypass getID() as well.

I tested this solution on my dedicated server, as well in a single player world.

I'm not a Minecraft mod developer, just found these bugs easy to solve. Please let me know if I can improve this solution.