### PR TITLE
Fixed null-pointer Exception on new entity speaker creation

### DIFF
--- a/src/main/java/io/github/foundationgames/phonos/client/ClientReceiverStorage.java
+++ b/src/main/java/io/github/foundationgames/phonos/client/ClientReceiverStorage.java
@@ -61,7 +61,7 @@ public class ClientReceiverStorage {
         for (int channel : entityStorage.keySet()) {
             removed.clear();
             for (var entity : entityStorage.get(channel)) {
-                if (entity.isRemoved()) removed.add(entity);
+                if (entity != null && entity.isRemoved()) removed.add(entity);
             }
             for (var entity : removed) {
                 entityStorage.get(channel).remove(entity);

--- a/src/main/java/io/github/foundationgames/phonos/sound/MultiPositionedSoundInstance.java
+++ b/src/main/java/io/github/foundationgames/phonos/sound/MultiPositionedSoundInstance.java
@@ -72,6 +72,7 @@ public class MultiPositionedSoundInstance extends AbstractSoundInstance implemen
             if(l.isWithinDistance(player.getEyePos(), 15*(volume/2))) near = true;
         }
         for(Entity e : entities) {
+            if(e == null) continue;
             double d = e.squaredDistanceTo(player.getEyePos());
             if(d < 950*(volume/2)) {
                 if(bd < 0 || d < bd) {


### PR DESCRIPTION
Just added a single check to see if the entity in the garbage collection list is null, preventing a crash on the tick when a speaker entity is added.