### PR TITLE
Fixed Crash When Unloading Radio Recorder

### DIFF
--- a/src/main/java/io/github/foundationgames/phonos/block/entity/RadioRecorderBlockEntity.java
+++ b/src/main/java/io/github/foundationgames/phonos/block/entity/RadioRecorderBlockEntity.java
@@ -63,7 +63,7 @@ public class RadioRecorderBlockEntity extends BlockEntity implements Syncing {
     }
 
     public static void tick(World world, BlockPos pos, BlockState state, RadioRecorderBlockEntity self) {
-        boolean powered = world.getBlockState(pos).get(Properties.POWERED);
+        boolean powered = state.get(Properties.POWERED);
 
         if (powered != self.powered) {
             self.powered = powered;

--- a/src/main/java/io/github/foundationgames/phonos/client/ClientReceiverStorage.java
+++ b/src/main/java/io/github/foundationgames/phonos/client/ClientReceiverStorage.java
@@ -70,6 +70,8 @@ public class ClientReceiverStorage {
                 if (entity.isRemoved()) removed.add(entity);
             }
             for (var entity : removed) {
+		if (entity == null) continue;
+		
                 entityStorage.get(channel).remove(entity);
             }
         }


### PR DESCRIPTION
This small change should fix #30 by using the given blockstate in the radio recorder, rather than querying the block at the radio recorder's location for it, which can cause issues when unloading. The second commit should fix #26 and #24 by checking if entity is null in the second for loop while garbage collecting